### PR TITLE
Updated Python version from 3.7 to 3.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "aws_lambda_function" "ec2_start_scheduler_lambda" {
   function_name = "start_instances"
   role = "${aws_iam_role.ec2_start_stop_scheduler.arn}"
   handler = "start_instances.lambda_handler"
-  runtime = "python3.7"
+  runtime = "python3.13"
   timeout = 300
   source_code_hash = "${data.archive_file.start_scheduler.output_base64sha256}"
 
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "ec2_stop_scheduler_lambda" {
   function_name = "stop_instances"
   role = "${aws_iam_role.ec2_start_stop_scheduler.arn}"
   handler = "stop_instances.lambda_handler"
-  runtime = "python3.7"
+  runtime = "python3.13"
   timeout = 300
   source_code_hash = "${data.archive_file.stop_scheduler.output_base64sha256}"
 

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,5 @@
+tag_key   = "Environment"
+tag_value = "Dev"
+region    = "us-east-1"
+schedule_expression_start = "cron(0 8 ? * MON-FRI *)"
+schedule_expression_stop  = "cron(0 18 ? * MON-FRI *)"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,5 +1,0 @@
-tag_key   = "Environment"
-tag_value = "Dev"
-region    = "us-east-1"
-schedule_expression_start = "cron(0 8 ? * MON-FRI *)"
-schedule_expression_stop  = "cron(0 18 ? * MON-FRI *)"


### PR DESCRIPTION
This update replaces all references to Python 3.7 with Python 3.13 to ensure compatibility with the latest stable version and avoid using deprecated runtimes.

